### PR TITLE
refactor: Phase 2 - Extract data models to separate module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,11 @@ git branch -d feature/your-branch-name
 - **Documentation**: `docs/update-readme`
 - **Refactoring**: `refactor/improve-code-structure`
 
+## Development Principles
+
+- **Branch Management**:
+  - 作業開始時はmainブランチをpullし、その最新コミット上でブランチを切り、その新しいブランチ上で作業すること。
+
 ## Dependencies
 
 Main dependencies:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,9 @@ git checkout -b fix/bug-description
    ```
 3. **Commit**: Use appropriate commit message conventions
    - Pre-commit hooks will automatically run
+   - **Pre-commit Hook Handling**: If pre-commit hooks fail and modify files:
+     - The commit will NOT be executed (no need to amend)
+     - Simply add the modified files and commit again: `git add . && git commit -m "your message"`
    - Ensure all hooks pass before pushing
 
 ### Creating Pull Requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**IMPORTANT**: All content in this file should be written in English to maintain consistency and clarity.
+
 ## Project Overview
 
 AutoJournalSummarizer is a Python application that automatically summarizes the latest papers from arXiv and sends notifications to Discord. The system includes:
@@ -88,7 +90,8 @@ docker compose run --rm --build prod
 docker compose up -d prod
 ```
 
-### CI/CD
+## CI/CD
+
 This project uses GitHub Actions for automated testing and code quality checks:
 
 - **CI Workflow** (`.github/workflows/ci.yml`): Runs on every push and PR
@@ -214,16 +217,14 @@ git pull origin main
 git branch -d feature/your-branch-name
 ```
 
-### Branch Naming Conventions
-- **Features**: `feature/add-new-functionality`
-- **Bug fixes**: `fix/resolve-specific-issue`
-- **Documentation**: `docs/update-readme`
-- **Refactoring**: `refactor/improve-code-structure`
+### Branch Management
+- **Naming Conventions**:
+  - Features: `feature/add-new-functionality`
+  - Bug fixes: `fix/resolve-specific-issue`
+  - Documentation: `docs/update-readme`
+  - Refactoring: `refactor/improve-code-structure`
 
-## Development Principles
-
-- **Branch Management**:
-  - 作業開始時はmainブランチをpullし、その最新コミット上でブランチを切り、その新しいブランチ上で作業すること。
+- **Branch Creation**: Always start work by pulling the latest main branch and creating new branches from the latest commit on main
 
 ## Dependencies
 

--- a/src/autojournalsummarizer/main.py
+++ b/src/autojournalsummarizer/main.py
@@ -8,38 +8,13 @@ from tempfile import TemporaryDirectory
 import arxiv  # type: ignore
 import requests
 from openai import OpenAI
-from pydantic import BaseModel
 from pydrive2.auth import GoogleAuth  # type: ignore
 from pydrive2.drive import GoogleDrive  # type: ignore
 from pypdf import PdfReader
 from pyzotero.zotero import Zotero  # type: ignore
 
 from .config import Settings, get_settings
-
-
-class Paper(BaseModel):
-    idx: int
-    title: str
-    reason: str
-
-
-class Papers(BaseModel):
-    papers: list[Paper]
-
-
-class Keyword(BaseModel):
-    keyword: str
-    explanation: str
-
-
-class PaperSummary(BaseModel):
-    japanese_title: str
-    summary: str
-    merit: str
-    method: str
-    valid: str
-    discussion: str
-    keywords: list[Keyword]
+from .models import Papers, PaperSummary
 
 
 def main(num_papers: int, model: str) -> None:

--- a/src/autojournalsummarizer/models/__init__.py
+++ b/src/autojournalsummarizer/models/__init__.py
@@ -1,0 +1,5 @@
+"""Data models for AutoJournalSummarizer."""
+
+from .paper import Keyword, Paper, Papers, PaperSummary
+
+__all__ = ["Paper", "Papers", "Keyword", "PaperSummary"]

--- a/src/autojournalsummarizer/models/paper.py
+++ b/src/autojournalsummarizer/models/paper.py
@@ -1,0 +1,38 @@
+"""Paper-related data models for structured data handling."""
+
+from pydantic import BaseModel, Field
+
+
+class Paper(BaseModel):
+    """Represents a filtered paper from arXiv search results."""
+
+    idx: int = Field(description="Index of the paper in the original search results")
+    title: str = Field(description="Title of the paper")
+    reason: str = Field(description="Reason why this paper was selected as interesting")
+
+
+class Papers(BaseModel):
+    """Collection of filtered papers."""
+
+    papers: list[Paper] = Field(description="List of interesting papers")
+
+
+class Keyword(BaseModel):
+    """Represents a keyword with its explanation."""
+
+    keyword: str = Field(description="The keyword term")
+    explanation: str = Field(description="Explanation of the keyword in Japanese")
+
+
+class PaperSummary(BaseModel):
+    """Structured summary of a research paper in Japanese."""
+
+    japanese_title: str = Field(description="Japanese translation of the paper title")
+    summary: str = Field(description="Brief summary in Japanese")
+    merit: str = Field(
+        description="What makes this paper superior to previous research"
+    )
+    method: str = Field(description="Key technical methods or approaches used")
+    valid: str = Field(description="How the effectiveness was validated")
+    discussion: str = Field(description="Limitations, challenges, or future work")
+    keywords: list[Keyword] = Field(description="Key technical terms with explanations")


### PR DESCRIPTION
## Summary
- Extract Pydantic data models (Paper, Papers, Keyword, PaperSummary) from main.py to dedicated models module
- Create structured models package with proper __init__.py and comprehensive documentation
- Update imports in main.py to use the separated models
- Add pre-commit hook handling guidance to CLAUDE.md

## Test plan
- [x] Verify all models are properly exported from models module
- [x] Confirm main.py imports and functionality remain intact
- [x] Ensure code passes all pre-commit hooks and type checking
- [x] Documentation updated with development workflow guidance

🤖 Generated with [Claude Code](https://claude.ai/code)