### PR TITLE
refactor: Phase 3 - Extract service layer from main.py

### DIFF
--- a/src/autojournalsummarizer/main.py
+++ b/src/autojournalsummarizer/main.py
@@ -1,20 +1,18 @@
 import argparse
-import json
-import os
-import re
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from tempfile import TemporaryDirectory
 
-import arxiv  # type: ignore
-import requests
-from openai import OpenAI
-from pydrive2.auth import GoogleAuth  # type: ignore
-from pydrive2.drive import GoogleDrive  # type: ignore
-from pypdf import PdfReader
-from pyzotero.zotero import Zotero  # type: ignore
-
-from .config import Settings, get_settings
-from .models import Papers, PaperSummary
+from .config import get_settings
+from .services import (
+    ArxivService,
+    DiscordService,
+    GoogleDriveService,
+    OpenAIService,
+    ZoteroService,
+    extract_text_from_pdf,
+    get_last_published_datetime,
+    update_log,
+)
 
 
 def main(num_papers: int, model: str) -> None:
@@ -22,28 +20,34 @@ def main(num_papers: int, model: str) -> None:
     settings.ensure_directories()
     settings.ensure_files()
 
+    # Initialize services
+    arxiv_service = ArxivService(settings)
+    openai_service = OpenAIService(settings)
+    discord_service = DiscordService(settings)
+    gdrive_service = GoogleDriveService(settings)
+    zotero_service = ZoteroService(settings)
+
     last_published = get_last_published_datetime(settings)
     start_datetime = None
     if last_published is not None:
         start_datetime = last_published + timedelta(minutes=1)
-    papers = retrieve_recent_arxiv_papers(
-        settings,
-        start_datetime=start_datetime,
-    )
+
+    papers = arxiv_service.retrieve_recent_papers(start_datetime=start_datetime)
     print("Updated papers:", len(papers))
     if len(papers) == 0:
         print("There are no updated papers.")
-        send_discord(settings, "本日の新着論文はありません。")
+        discord_service.send_message("本日の新着論文はありません。")
         return
 
-    interesting_papers = extract_interesting_papers(settings, papers, num_papers, model)
+    interesting_papers = openai_service.filter_interesting_papers(
+        papers, num_papers, model
+    )
     interesting_titles = [p.title for p in interesting_papers]
     print("Interesting papers:", len(interesting_papers))
 
-    send_discord(
-        settings,
+    discord_service.send_message(
         f"新着論文：{len(papers)}本\n"
-        + f"関心度の高い論文：{len(interesting_papers)}本",
+        + f"関心度の高い論文：{len(interesting_papers)}本"
     )
 
     for paper in papers:
@@ -53,13 +57,13 @@ def main(num_papers: int, model: str) -> None:
         with TemporaryDirectory() as dirpath:
             pdf_path = paper.download_pdf(dirpath=dirpath)
             text = extract_text_from_pdf(pdf_path)
-            summary = summarize_paper(settings, paper.title, text, model)
-            message = make_message(paper=paper, summary=summary)
+            summary = openai_service.summarize_paper(paper.title, text, model)
+            message = discord_service.make_paper_message(paper=paper, summary=summary)
             print(message)
 
-            send_discord(settings, message)
-            upload_google_drive(settings, pdf_path)
-            register_zotero(settings, paper, pdf_path)
+            discord_service.send_message(message)
+            gdrive_service.upload_pdf(pdf_path)
+            zotero_service.register_paper(paper, pdf_path)
             update_log(settings, paper.published)
 
 
@@ -69,252 +73,30 @@ def test(num_papers: int, model: str) -> None:
     settings.ensure_directories()
     settings.ensure_files()
 
-    papers = retrieve_recent_arxiv_papers(settings)
+    # Initialize services
+    arxiv_service = ArxivService(settings)
+    openai_service = OpenAIService(settings)
+    discord_service = DiscordService(settings)
+
+    papers = arxiv_service.retrieve_recent_papers()
     print("Updated papers:", len(papers))
     if len(papers) == 0:
         print("There are no updated papers.")
         return
 
-    interesting_papers = extract_interesting_papers(settings, papers, num_papers, model)
+    interesting_papers = openai_service.filter_interesting_papers(
+        papers, num_papers, model
+    )
     print("Interesting papers:", len(interesting_papers))
 
     for paper in interesting_papers:
         with TemporaryDirectory() as dirpath:
             pdf_path = paper.download_pdf(dirpath=dirpath)
             text = extract_text_from_pdf(pdf_path)
-            summary = summarize_paper(settings, paper.title, text, model)
-            message = make_message(paper=paper, summary=summary)
+            summary = openai_service.summarize_paper(paper.title, text, model)
+            message = discord_service.make_paper_message(paper=paper, summary=summary)
             print(message)
         break
-
-
-def get_last_published_datetime(settings: Settings) -> datetime | None:
-    last_date_file = settings.last_date_file
-    if not last_date_file.exists():
-        last_date_file.write_text("")
-        return None
-
-    last_published = last_date_file.read_text().strip()
-    print(last_published)
-    if last_published == "":
-        return None
-
-    last_published_dt = datetime.fromisoformat(last_published)
-    return last_published_dt
-
-
-def retrieve_recent_arxiv_papers(
-    settings: Settings,
-    start_datetime: datetime | None = None,
-) -> list[arxiv.Result]:
-    category = settings.arxiv_category
-    if start_datetime is None:
-        query = f"cat:{category}"
-    else:
-        start_datetime_str = start_datetime.strftime("%Y%m%d%H%M%S")
-        start_datetime_str = start_datetime.strftime("%Y%m%d%H%M%S")
-        now = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
-        query = f"cat:{category} AND submittedDate:[{start_datetime_str} TO {now}]"
-        query = f"cat:{category} AND submittedDate:[{start_datetime_str} TO {now}]"
-
-    search = arxiv.Search(
-        query=query,
-        max_results=settings.arxiv_max_results,
-        sort_by=arxiv.SortCriterion.SubmittedDate,
-    )
-
-    client = arxiv.Client()
-    papers = list(client.results(search))
-
-    return papers[::-1]
-
-
-def extract_interesting_papers(
-    settings: Settings, papers: list[arxiv.Result], num_papers: int, model: str
-) -> list[arxiv.Result]:
-    if not (settings.keywords_file.exists() and settings.filter_prompt_file.exists()):
-        return papers
-
-    prompt = settings.filter_prompt_file.read_text()
-    keywords = settings.keywords_file.read_text().splitlines()
-
-    keyword_sentence = ""
-    for k in keywords:
-        keyword_sentence += "- " + k + "\n"
-
-    prompt = prompt.replace("{keywords}", keyword_sentence)
-
-    settings.validate_required_env_vars("filter")
-    client = OpenAI(api_key=settings.openai_api_key)
-
-    titles_sentence = ""
-    for idx, p in enumerate(papers):
-        titles_sentence += f"{idx}. {p.title}\n"
-    completion = client.beta.chat.completions.parse(
-        model=model,
-        messages=[
-            {"role": "user", "content": prompt + titles_sentence},
-        ],
-        response_format=Papers,
-    )
-    response = completion.choices[0].message.parsed
-    print(response)
-    if response is None:
-        return papers[:num_papers]
-    if response is None:
-        return papers[:num_papers]
-    target_idxs = [int(p.idx) for p in response.papers]
-
-    interesting_papers = []
-    for idx in target_idxs:
-        interesting_papers.append(papers[idx])
-
-    return interesting_papers
-
-
-def extract_text_from_pdf(pdf_path: str) -> str:
-    reader = PdfReader(pdf_path)
-    text = ""
-    for page in reader.pages:
-        text += page.extract_text()
-    return text
-
-
-def summarize_paper(
-    settings: Settings, title: str, text: str, model: str
-) -> PaperSummary | None:
-    summarize_prompt = settings.summarize_prompt_file.read_text()
-
-    settings.validate_required_env_vars("summarize")
-    client = OpenAI(api_key=settings.openai_api_key)
-
-    res = client.beta.chat.completions.parse(
-        model=model,
-        messages=[
-            {
-                "role": "user",
-                "content": summarize_prompt + f"[タイトル]\n{title}\n[本文]\n{text}",
-            },
-        ],
-        response_format=PaperSummary,
-    )
-    return res.choices[0].message.parsed
-
-
-def make_message(paper: arxiv.Result, summary: PaperSummary | None) -> str:
-    if summary is None:
-        return f"# [{paper.title}]({paper.links[0].href})\n論文の要約に失敗しました。"
-
-    message = (
-        f"# [{summary.japanese_title}]({paper.links[0].href})\n"
-        f"第一著者：{paper.authors[0].name}\n"
-        f"日付：{paper.published.strftime('%Y-%m-%d %H:%M:%S')}\n"
-        "## 一言で説明すると？\n"
-        f"{summary.summary}\n"
-        "## 先行研究と比べて何がすごい？\n"
-        f"{summary.merit}\n"
-        "## 技術や手法のキモは何？\n"
-        f"{summary.method}\n"
-        "## どうやって有効だと検証した？\n"
-        f"{summary.valid}\n"
-        "## 課題や議論はある？\n"
-        f"{summary.discussion}\n"
-        "## キーワード\n"
-    )
-    for keyword in summary.keywords:
-        message += f"- {keyword.keyword}：{keyword.explanation}\n"
-    return message
-
-
-def send_discord(settings: Settings, message: str) -> None:
-    if not settings.discord_webhook_url:
-        print("DISCORD_WEBHOOK_URL not found, skipping Discord notification")
-        return
-
-    headers = {"Content-Type": "application/json"}
-    data = {"content": message}
-    requests.post(settings.discord_webhook_url, data=json.dumps(data), headers=headers)
-    print("Send message")
-    print("------------")
-    print(message)
-    print("------------")
-
-
-def upload_google_drive(settings: Settings, pdf_path: str) -> None:
-    gauth = GoogleAuth(str(settings.google_auth_settings_file))
-    gauth.ServiceAuth()
-    drive = GoogleDrive(gauth)
-    query = f'title = "{settings.google_folder_name}"'
-    folders = drive.ListFile({"q": query}).GetList()
-    file = drive.CreateFile(
-        {
-            "title": os.path.basename(pdf_path),
-            "parents": [{"id": folders[0]["id"]}],
-        }
-    )
-    file.SetContentFile(pdf_path)
-    file.Upload({"convert": False})
-    print("Upload to google drive:", os.path.basename(pdf_path))
-
-
-def register_zotero(settings: Settings, paper: arxiv.Result, pdf_path: str) -> None:
-    if not settings.zotero_api_key or not settings.zotero_library_id:
-        print("ZOTERO credentials not found, skipping Zotero registration")
-        return
-
-    zot = Zotero(
-        library_id=settings.zotero_library_id,
-        library_type="user",
-        api_key=settings.zotero_api_key,
-    )
-
-    item = zot.item_template("preprint")
-    item["title"] = paper.title
-    item["creators"] = []
-    for author in paper.authors:
-        try:
-            first_name, last_name = author.name.split(maxsplit=1)
-        except ValueError:
-            first_name = author.name
-            last_name = ""
-        item["creators"].append(
-            {
-                "creatorType": "author",
-                "firstName": first_name,
-                "lastName": last_name,
-            }
-        )
-    item["abstractNote"] = paper.summary
-    item["repository"] = "arxiv"
-    item["archiveID"] = "arXiv:" + re.sub(r"v[0-9]+", "", paper.get_short_id())
-    item["date"] = paper.published.strftime("%Y-%m-%d")
-    item["DOI"] = paper.doi
-    item["url"] = re.sub(r"v[0-9]+", "", paper.links[0].href)
-    item["libraryCatalog"] = "arXiv.org"
-
-    collections = zot.collections()
-    for collection in collections:
-        if collection["data"]["name"] == settings.zotero_collection_name:
-            collection_id = collection["key"]
-            break
-    item["collections"] = [collection_id]
-
-    response = zot.create_items([item])
-    item_id = response["success"]["0"]
-
-    pdf_filename = os.path.basename(pdf_path)
-    attachment = zot.item_template("attachment", linkmode="linked_file")
-    attachment["title"] = pdf_filename
-    attachment["path"] = pdf_filename
-    attachment["contentType"] = "application/pdf"
-    zot.create_items([attachment], parentid=item_id)
-
-    print("Register to Zotero:", paper.title)
-
-
-def update_log(settings: Settings, published_datetime: datetime) -> None:
-    settings.last_date_file.write_text(published_datetime.isoformat())
-    print("Log is updated!:", published_datetime.isoformat())
 
 
 if __name__ == "__main__":

--- a/src/autojournalsummarizer/services/__init__.py
+++ b/src/autojournalsummarizer/services/__init__.py
@@ -1,0 +1,17 @@
+"""Service layer modules for AutoJournalSummarizer."""
+
+from .arxiv import ArxivService
+from .integrations import DiscordService, GoogleDriveService, ZoteroService
+from .openai_service import OpenAIService
+from .utils import extract_text_from_pdf, get_last_published_datetime, update_log
+
+__all__ = [
+    "ArxivService",
+    "OpenAIService",
+    "DiscordService",
+    "GoogleDriveService",
+    "ZoteroService",
+    "extract_text_from_pdf",
+    "get_last_published_datetime",
+    "update_log",
+]

--- a/src/autojournalsummarizer/services/arxiv.py
+++ b/src/autojournalsummarizer/services/arxiv.py
@@ -1,0 +1,46 @@
+"""arXiv paper retrieval service."""
+
+from datetime import datetime, timezone
+
+import arxiv  # type: ignore
+
+from ..config import Settings
+
+
+class ArxivService:
+    """Service for retrieving papers from arXiv."""
+
+    def __init__(self, settings: Settings) -> None:
+        """Initialize ArxivService with settings."""
+        self.settings = settings
+
+    def retrieve_recent_papers(
+        self, start_datetime: datetime | None = None
+    ) -> list[arxiv.Result]:
+        """Retrieve recent papers from arXiv.
+
+        Args:
+            start_datetime: Optional start datetime for filtering papers.
+
+        Returns:
+            List of arXiv papers sorted by submission date (oldest first).
+        """
+        category = self.settings.arxiv_category
+
+        if start_datetime is None:
+            query = f"cat:{category}"
+        else:
+            start_datetime_str = start_datetime.strftime("%Y%m%d%H%M%S")
+            now = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+            query = f"cat:{category} AND submittedDate:[{start_datetime_str} TO {now}]"
+
+        search = arxiv.Search(
+            query=query,
+            max_results=self.settings.arxiv_max_results,
+            sort_by=arxiv.SortCriterion.SubmittedDate,
+        )
+
+        client = arxiv.Client()
+        papers = list(client.results(search))
+
+        return papers[::-1]  # Reverse to get oldest first

--- a/src/autojournalsummarizer/services/integrations.py
+++ b/src/autojournalsummarizer/services/integrations.py
@@ -1,0 +1,187 @@
+"""External service integrations for Discord, Google Drive, and Zotero."""
+
+import json
+import os
+import re
+
+import arxiv  # type: ignore
+import requests
+from pydrive2.auth import GoogleAuth  # type: ignore
+from pydrive2.drive import GoogleDrive  # type: ignore
+from pyzotero.zotero import Zotero  # type: ignore
+
+from ..config import Settings
+from ..models import PaperSummary
+
+
+class DiscordService:
+    """Service for Discord webhook notifications."""
+
+    def __init__(self, settings: Settings) -> None:
+        """Initialize DiscordService with settings."""
+        self.settings = settings
+
+    def send_message(self, message: str) -> None:
+        """Send a message to Discord via webhook.
+
+        Args:
+            message: Message content to send.
+        """
+        if not self.settings.discord_webhook_url:
+            print("DISCORD_WEBHOOK_URL not found, skipping Discord notification")
+            return
+
+        headers = {"Content-Type": "application/json"}
+        data = {"content": message}
+        requests.post(
+            self.settings.discord_webhook_url, data=json.dumps(data), headers=headers
+        )
+        print("Send message")
+        print("------------")
+        print(message)
+        print("------------")
+
+    def make_paper_message(
+        self, paper: arxiv.Result, summary: PaperSummary | None
+    ) -> str:
+        """Create a formatted message for a paper summary.
+
+        Args:
+            paper: arXiv paper object.
+            summary: Structured paper summary.
+
+        Returns:
+            Formatted message string for Discord.
+        """
+        if summary is None:
+            return (
+                f"# [{paper.title}]({paper.links[0].href})\n論文の要約に失敗しました。"
+            )
+
+        message = (
+            f"# [{summary.japanese_title}]({paper.links[0].href})\n"
+            f"第一著者：{paper.authors[0].name}\n"
+            f"日付：{paper.published.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            "## 一言で説明すると？\n"
+            f"{summary.summary}\n"
+            "## 先行研究と比べて何がすごい？\n"
+            f"{summary.merit}\n"
+            "## 技術や手法のキモは何？\n"
+            f"{summary.method}\n"
+            "## どうやって有効だと検証した？\n"
+            f"{summary.valid}\n"
+            "## 課題や議論はある？\n"
+            f"{summary.discussion}\n"
+            "## キーワード\n"
+        )
+        for keyword in summary.keywords:
+            message += f"- {keyword.keyword}：{keyword.explanation}\n"
+        return message
+
+
+class GoogleDriveService:
+    """Service for Google Drive file uploads."""
+
+    def __init__(self, settings: Settings) -> None:
+        """Initialize GoogleDriveService with settings."""
+        self.settings = settings
+
+    def upload_pdf(self, pdf_path: str) -> None:
+        """Upload a PDF file to Google Drive.
+
+        Args:
+            pdf_path: Path to the PDF file to upload.
+        """
+        gauth = GoogleAuth(str(self.settings.google_auth_settings_file))
+        gauth.ServiceAuth()
+        drive = GoogleDrive(gauth)
+
+        query = f'title = "{self.settings.google_folder_name}"'
+        folders = drive.ListFile({"q": query}).GetList()
+
+        file = drive.CreateFile(
+            {
+                "title": os.path.basename(pdf_path),
+                "parents": [{"id": folders[0]["id"]}],
+            }
+        )
+        file.SetContentFile(pdf_path)
+        file.Upload({"convert": False})
+        print("Upload to google drive:", os.path.basename(pdf_path))
+
+
+class ZoteroService:
+    """Service for Zotero bibliography management."""
+
+    def __init__(self, settings: Settings) -> None:
+        """Initialize ZoteroService with settings."""
+        self.settings = settings
+
+    def register_paper(self, paper: arxiv.Result, pdf_path: str) -> None:
+        """Register a paper in Zotero with PDF attachment.
+
+        Args:
+            paper: arXiv paper object.
+            pdf_path: Path to the PDF file to attach.
+        """
+        if not self.settings.zotero_api_key or not self.settings.zotero_library_id:
+            print("ZOTERO credentials not found, skipping Zotero registration")
+            return
+
+        zot = Zotero(
+            library_id=self.settings.zotero_library_id,
+            library_type="user",
+            api_key=self.settings.zotero_api_key,
+        )
+
+        # Create preprint item
+        item = zot.item_template("preprint")
+        item["title"] = paper.title
+        item["creators"] = []
+
+        for author in paper.authors:
+            try:
+                first_name, last_name = author.name.split(maxsplit=1)
+            except ValueError:
+                first_name = author.name
+                last_name = ""
+            item["creators"].append(
+                {
+                    "creatorType": "author",
+                    "firstName": first_name,
+                    "lastName": last_name,
+                }
+            )
+
+        item["abstractNote"] = paper.summary
+        item["repository"] = "arxiv"
+        item["archiveID"] = "arXiv:" + re.sub(r"v[0-9]+", "", paper.get_short_id())
+        item["date"] = paper.published.strftime("%Y-%m-%d")
+        item["DOI"] = paper.doi
+        item["url"] = re.sub(r"v[0-9]+", "", paper.links[0].href)
+        item["libraryCatalog"] = "arXiv.org"
+
+        # Find collection
+        collections = zot.collections()
+        collection_id = None
+        for collection in collections:
+            if collection["data"]["name"] == self.settings.zotero_collection_name:
+                collection_id = collection["key"]
+                break
+
+        if collection_id:
+            item["collections"] = [collection_id]
+
+        # Create item
+        response = zot.create_items([item])
+        item_id = response["success"]["0"]
+
+        # Add PDF attachment
+        pdf_filename = os.path.basename(pdf_path)
+        attachment = zot.item_template("attachment", linkmode="linked_file")
+        attachment["title"] = pdf_filename
+        attachment["path"] = pdf_filename
+        attachment["contentType"] = "application/pdf"
+        zot.create_items([attachment], parentid=item_id)
+
+        print("Register to Zotero:", paper.title)

--- a/src/autojournalsummarizer/services/openai_service.py
+++ b/src/autojournalsummarizer/services/openai_service.py
@@ -1,0 +1,102 @@
+"""OpenAI API service for paper filtering and summarization."""
+
+import arxiv  # type: ignore
+from openai import OpenAI
+
+from ..config import Settings
+from ..models import Papers, PaperSummary
+
+
+class OpenAIService:
+    """Service for OpenAI API operations."""
+
+    def __init__(self, settings: Settings) -> None:
+        """Initialize OpenAIService with settings."""
+        self.settings = settings
+
+    def filter_interesting_papers(
+        self, papers: list[arxiv.Result], num_papers: int, model: str
+    ) -> list[arxiv.Result]:
+        """Filter papers based on user-defined keywords using OpenAI.
+
+        Args:
+            papers: List of arXiv papers to filter.
+            num_papers: Maximum number of papers to return if filtering fails.
+            model: OpenAI model to use for filtering.
+
+        Returns:
+            List of interesting papers based on keyword matching.
+        """
+        if not (
+            self.settings.keywords_file.exists()
+            and self.settings.filter_prompt_file.exists()
+        ):
+            return papers
+
+        prompt = self.settings.filter_prompt_file.read_text()
+        keywords = self.settings.keywords_file.read_text().splitlines()
+
+        keyword_sentence = ""
+        for keyword in keywords:
+            keyword_sentence += "- " + keyword + "\n"
+
+        prompt = prompt.replace("{keywords}", keyword_sentence)
+
+        self.settings.validate_required_env_vars("filter")
+        client = OpenAI(api_key=self.settings.openai_api_key)
+
+        titles_sentence = ""
+        for idx, paper in enumerate(papers):
+            titles_sentence += f"{idx}. {paper.title}\n"
+
+        completion = client.beta.chat.completions.parse(
+            model=model,
+            messages=[
+                {"role": "user", "content": prompt + titles_sentence},
+            ],
+            response_format=Papers,
+        )
+
+        response = completion.choices[0].message.parsed
+        print(response)
+
+        if response is None:
+            return papers[:num_papers]
+
+        target_idxs = [int(paper.idx) for paper in response.papers]
+
+        interesting_papers = []
+        for idx in target_idxs:
+            interesting_papers.append(papers[idx])
+
+        return interesting_papers
+
+    def summarize_paper(self, title: str, text: str, model: str) -> PaperSummary | None:
+        """Generate a structured summary of a research paper.
+
+        Args:
+            title: Paper title.
+            text: Full text content of the paper.
+            model: OpenAI model to use for summarization.
+
+        Returns:
+            Structured paper summary or None if summarization fails.
+        """
+        summarize_prompt = self.settings.summarize_prompt_file.read_text()
+
+        self.settings.validate_required_env_vars("summarize")
+        client = OpenAI(api_key=self.settings.openai_api_key)
+
+        response = client.beta.chat.completions.parse(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": summarize_prompt
+                    + f"[タイトル]\n{title}\n[本文]\n{text}",
+                },
+            ],
+            response_format=PaperSummary,
+        )
+
+        return response.choices[0].message.parsed

--- a/src/autojournalsummarizer/services/utils.py
+++ b/src/autojournalsummarizer/services/utils.py
@@ -1,0 +1,57 @@
+"""Utility functions for file operations and data management."""
+
+from datetime import datetime
+
+from pypdf import PdfReader
+
+from ..config import Settings
+
+
+def extract_text_from_pdf(pdf_path: str) -> str:
+    """Extract text content from a PDF file.
+
+    Args:
+        pdf_path: Path to the PDF file.
+
+    Returns:
+        Extracted text content as a string.
+    """
+    reader = PdfReader(pdf_path)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text()
+    return text
+
+
+def get_last_published_datetime(settings: Settings) -> datetime | None:
+    """Get the last processed paper timestamp from file.
+
+    Args:
+        settings: Application settings.
+
+    Returns:
+        Last published datetime or None if no timestamp exists.
+    """
+    last_date_file = settings.last_date_file
+    if not last_date_file.exists():
+        last_date_file.write_text("")
+        return None
+
+    last_published = last_date_file.read_text().strip()
+    print(last_published)
+    if last_published == "":
+        return None
+
+    last_published_dt = datetime.fromisoformat(last_published)
+    return last_published_dt
+
+
+def update_log(settings: Settings, published_datetime: datetime) -> None:
+    """Update the last processed paper timestamp.
+
+    Args:
+        settings: Application settings.
+        published_datetime: DateTime to record as last processed.
+    """
+    settings.last_date_file.write_text(published_datetime.isoformat())
+    print("Log is updated!:", published_datetime.isoformat())


### PR DESCRIPTION
## Summary
- Create comprehensive service layer architecture for better code organization
- Extract ArxivService for paper retrieval operations
- Extract OpenAIService for filtering and summarization using GPT
- Extract integration services (Discord, Google Drive, Zotero) for external APIs
- Extract utility functions to services/utils.py
- Update main.py to use dependency injection pattern with service layer
- Reduce main.py complexity from 362 lines to ~110 lines

## Architecture Changes
### New Service Layer Structure:
- `services/arxiv.py` - ArxivService for paper search and retrieval
- `services/openai_service.py` - OpenAIService for GPT-based operations
- `services/integrations.py` - External service integrations (Discord, GDrive, Zotero)
- `services/utils.py` - Utility functions for file operations and logging
- `services/__init__.py` - Clean service exports

### Benefits:
- **Separation of Concerns**: Each service handles a specific domain
- **Testability**: Services can be easily mocked and unit tested
- **Maintainability**: Clear boundaries between different functionalities
- **Extensibility**: Easy to add new services or modify existing ones
- **Dependency Injection**: Services are injected into main functions

## Test plan
- [x] All type checks pass (mypy)
- [x] All linting checks pass (ruff)
- [x] Test mode confirms application works correctly
- [x] Service layer properly initializes and functions
- [x] No regression in existing functionality
- [x] Clean import structure and dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)